### PR TITLE
Add pyxdg ad requred dependencie

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Example output:
 - i3ipc
 - pillow
 - xdg
+- pyxdg
 # Usage
 
 ## Compile and install

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pygame
 i3ipc
 pillow
 xdg
+pyxdg


### PR DESCRIPTION
### Issue
After installing i3expo-ng and and launching the program with: ` ~/.local/bin/i3expod.py`,
i noticed a dependency error with this output

`  File "/home/alfonso/.local/bin/i3expod.py", line 22, in <module>
    from xdg.BaseDirectory import xdg_config_home
ModuleNotFoundError: No module named 'xdg.BaseDirectory'`

So i solved it by downloading pyxdg from pip with: `pip install pyxdg`

And now i can launch the program. 

I believe that it needs to be added as a required dependency