### PR TITLE
Fix xdg import and config file path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CONFIG_DIR?=$(shell echo "$${XDG_CONFIG_HOME-$$HOME}/.config/i3expo")
+CONFIG_DIR?=$(shell echo "$${XDG_CONFIG_HOME-$$HOME}/i3expo")
 CONFIG_FILE=$(CONFIG_DIR)/config
 # The local files we need to install
 TARGETS=prtscn.so i3expod.py

--- a/i3expod.py
+++ b/i3expod.py
@@ -19,7 +19,11 @@ import random
 import subprocess
 import math
 from threading import Thread
-from xdg import xdg_config_home
+try:
+    from xdg import xdg_config_home
+    xdg_config_home = str(xdg_config_home())
+except ImportError:
+    from xdg.BaseDirectory import xdg_config_home
 from contextlib import suppress
 from PIL import Image, ImageFilter, ImageEnhance, Image, ImageDraw
 
@@ -180,7 +184,7 @@ defaults = {
 }
 
 def read_config():
-    config.read(os.path.join(str(xdg_config_home()), "i3expo", "config"))
+    config.read(os.path.join(xdg_config_home, "i3expo", "config"))
     # Read custom labels for output names (if any)
     for key in config['OUTPUT_ALIASES']:
         global_knowledge['out_aliases'][key] = config['OUTPUT_ALIASES'][key]

--- a/i3expod.py
+++ b/i3expod.py
@@ -19,7 +19,7 @@ import random
 import subprocess
 import math
 from threading import Thread
-from xdg.BaseDirectory import xdg_config_home
+from xdg import xdg_config_home
 from contextlib import suppress
 from PIL import Image, ImageFilter, ImageEnhance, Image, ImageDraw
 
@@ -180,7 +180,7 @@ defaults = {
 }
 
 def read_config():
-    config.read(os.path.join(xdg_config_home, "i3expo", "config"))
+    config.read(os.path.join(str(xdg_config_home()), "i3expo", "config"))
     # Read custom labels for output names (if any)
     for key in config['OUTPUT_ALIASES']:
         global_knowledge['out_aliases'][key] = config['OUTPUT_ALIASES'][key]


### PR DESCRIPTION
First of all, thank you for the great work! I've been looking for something like this for a while.

I ran into a couple of small issues when I installed it on:
```
Fedora 33
Python 3.9.5
pip3 20.2.2
```
 
1. `ModuleNotFoundError: No module named 'xdg.BaseDirectory'`

I solved it by replacing the import with:
```
from xdg import xdg_config_home
```
But is this just my case? I checked the docs on [xdg](https://pypi.org/project/xdg/) and it reflects the same method as my system however it works on your system. Comments on this?

2. `'KeyError': 'OUTPUT_ALIASES'`

After running `make install`, the default configuration did not get copied into `XDG_CONFIG_HOME/i3expo` (i.e. `~/.config/i3expo`). It looks like it gets copied to `XDG_CONFIG_HOME/.config/i3expo` (i.e. `.config/.config/i3expo`). I addressed this by modifying the path in the `Makefile`.

Looking forward to your suggestions and comments!