### PR TITLE
On multi-monitor only get the primary monitor size

### DIFF
--- a/i3expod.py
+++ b/i3expod.py
@@ -60,6 +60,19 @@ def get_primary_output_monitor_size():
     return monitor_size
 
 
+def get_primary_output_monitor_displacement():
+    xrandr_query = f"xrandr --query | awk -F '[ +]' '/{get_primary_output_name()}/{{print $5,$6}}'"
+    stdout,stderr = subprocess.Popen(xrandr_query, shell=True,
+                    stdout=subprocess.PIPE).communicate()
+
+    out = stdout.decode('utf-8')
+    displacement = out[:out.find('\n')].replace(' ', ',')
+
+    return displacement
+
+# We can set the position of the window by using SDL environment variable
+os.environ['SDL_VIDEO_WINDOW_POS'] = get_primary_output_monitor_displacement()
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", "--fullscreen", action="store_true",
                     help="run in fullscreen")

--- a/i3expod.py
+++ b/i3expod.py
@@ -46,6 +46,18 @@ def get_primary_output_name():
     return None
 
 
+def get_primary_output_monitor_size():
+    xrandr_query = f"xrandr --query | awk -F '[ +]' '/{get_primary_output_name()}/{{print $4}}'"
+    stdout,stderr = subprocess.Popen(xrandr_query, shell=True,
+                    stdout=subprocess.PIPE).communicate()
+
+    # The stdout from awk needs to be decoded, stripped from newline and split
+    # The output should be similar to: b'1920x1080\n', we want a list instead
+    monitor_size = list(map(int, stdout.decode('utf-8').strip().split('x')))
+
+    return monitor_size
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", "--fullscreen", action="store_true",
                     help="run in fullscreen")
@@ -308,7 +320,7 @@ def show_ui():
     outputs = global_knowledge["outputs"]
 
     # Get monitor size
-    monitor_size = (pygame.display.Info().current_w, pygame.display.Info().current_h)
+    monitor_size = get_primary_output_monitor_size()
 
     # Calculate grid size in a more efficient way taking into account orientation:
     # Vertical screens take about 1/3 of the horizontal size so we can fit more frames in a row.

--- a/i3expod.py
+++ b/i3expod.py
@@ -52,8 +52,10 @@ def get_primary_output_monitor_size():
                     stdout=subprocess.PIPE).communicate()
 
     # The stdout from awk needs to be decoded, stripped from newline and split
-    # The output should be similar to: b'1920x1080\n', we want a list instead
-    monitor_size = list(map(int, stdout.decode('utf-8').strip().split('x')))
+    # The output should be similar to: b'1920x1080\n\left\left', we want a list instead
+    out = stdout.decode('utf-8')
+    # We want to cut the string at the first \n
+    monitor_size = list(map(int, out[:out.find('\n')].strip().split('x')))
 
     return monitor_size
 


### PR DESCRIPTION
Currently, when we run i3expo on a multi-monitor setup, the layout gets picked up by `pygame` as only one large screen and so it shows the UI over multiple screens, breaking the flow of the UI. To address this, we now use `xrandr` and `awk` to get the primary display's resolution.

# Current state
### Without fullscreen
**Left**: The multi-monitor layout. **Right**: When running `i3expo` without fullscreen, the UI is too large.
![three_screens_no_fullscreen](https://user-images.githubusercontent.com/1218851/124478579-e84d0180-ddd7-11eb-915d-da6e7c4f5ee1.png)


### With fullscreen
**Left**: The multi-monitor layout. **Right**: When running `i3expo` in fullscreen, the UI is shown over the three screens and breaks the flow of the UI.
![three_screens_fullscreen](https://user-images.githubusercontent.com/1218851/124474680-68249d00-ddd3-11eb-8f1b-35ecd15379d4.png)


# With this commit
### Without fullscreen
**Left**: The multi-monitor layout. **Right**: When running `i3expo` without fullscreen, UI is the correct proportion to the primary. monitor.
![three_screens_no_fullscreen_fix](https://user-images.githubusercontent.com/1218851/124478483-cf445080-ddd7-11eb-91f1-107de698df10.png)


However, note that the window is still a bit bigger but using i3's fullscreen fixes this:
![three_screens_no_fullscreen2_fix](https://user-images.githubusercontent.com/1218851/124478506-d66b5e80-ddd7-11eb-9d2c-618bcef1b5b6.png)


### With fullscreen
**Left**: The multi-monitor layout. **Right**: When running `i3expo` in fullscreen, UI is *still* shown over the three screens but the UI is the correct proportion to the primary display. Future work.
![three_screens_fullscreen_fix](https://user-images.githubusercontent.com/1218851/124475419-44ae2200-ddd4-11eb-87a3-ff60cefd0f9a.png)

I tested it using a single monitor and it works as expected. Looking forward to your comments!