### PR TITLE
change xdg to xdg-base-dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example output:
 - PyGame
 - i3ipc
 - pillow
-- xdg
+- xdg-base-dirs
 - pyxdg
 # Usage
 

--- a/i3expod.py
+++ b/i3expod.py
@@ -18,7 +18,7 @@ from threading import Thread
 import prtscn
 
 try:
-    from xdg import xdg_config_home
+    from xdg_base_dirs import xdg_config_home
 
     xdg_config_home = str(xdg_config_home())
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pygame
 i3ipc
 pillow
-xdg
+xdg-base-dirs
 pyxdg

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'pygame',
         'i3ipc',
         'pillow',
-        'xdg',
+        'xdg-base-dirs',
         'pyxdg',
     ],
     entry_points={


### PR DESCRIPTION
The update to v6.0.0 is a change in naming according to https://github.com/srstevenson/xdg-base-dirs