### PR TITLE
Replace deprecated xdg package

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example output:
 - PyGame
 - i3ipc
 - pillow
-- xdg
+- xdg-base-dirs
 - pyxdg
 # Usage
 

--- a/i3expod.py
+++ b/i3expod.py
@@ -18,11 +18,11 @@ from threading import Thread
 import prtscn
 
 try:
-    from xdg import xdg_config_home
+    from xdg_base_dirs import xdg_config_home
 
     xdg_config_home = str(xdg_config_home())
 except ImportError:
-    from xdg.BaseDirectory import xdg_config_home
+    from xdg_base_dirs import xdg_config_home
 from contextlib import suppress
 from PIL import ImageFilter, ImageEnhance, Image
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pygame
 i3ipc
 pillow
-xdg
+xdg-base-dirs
 pyxdg

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'pygame',
         'i3ipc',
         'pillow',
-        'xdg',
+        'xdg-base-dirs',
         'pyxdg',
     ],
     entry_points={


### PR DESCRIPTION
The `xdg`  was renamed to `xdg-base-dirs`

- https://pypi.org/project/xdg/
- https://pypi.org/project/xdg-base-dirs/